### PR TITLE
Fix errors in rx_download project guide

### DIFF
--- a/rx_download/UART-Receiver_synth.md
+++ b/rx_download/UART-Receiver_synth.md
@@ -29,7 +29,7 @@ Include the following ports and parameters in your module:
 | Parameter Name | Default Value | Purpose |
 | ---- | ---- | ---- |
 | CLK_FREQUECY | 100_000_000 | The clock frequency |
-| SEGMENT_DISPLAY_US  | 10_000 | The amount of time to display each digit  |
+| MIN_SEGMENT_DISPLAY_US  | 10_000 | The amount of time to display each digit  |
  
 The anode signals should be driven in a round-robin fashion so that each digit is displayed for a short amount of time.
 These signals are low asserted. 
@@ -86,8 +86,8 @@ Create a top-level design that uses the following top-level ports:
 | CLK_FREQUENCY  | 100_000_000 | Specify the clock frequency |
 | BAUD_RATE | 19_200 | Specify the receiver baud rate |
 | PARITY | 1 | Specify the parity bit (0 = even, 1 = odd) |
-| SEGMENT_DISPLAY_US  | 1_000 | The amount of time in microseconds to display each digit (1 ms) |
-| DEBOUNCE_DELAY_US | integer | 1_000 | Specifies the minimum debounce delay in micro seconds (1 ms) |
+| MIN_SEGMENT_DISPLAY_US  | 1_000 | The amount of time in microseconds to display each digit (1 ms) |
+| DEBOUNCE_TIME_US | integer | 1_000 | Specifies the minimum debounce delay in micro seconds (1 ms) |
 
 Design your top-level circuit as follows:
 * Attach the `CPU_RESETN` signal to two flip-flops to synchronize it to the clock. Use this synchronized signal for the reset in your design (note that the input reset polarity is negative asserted)


### PR DESCRIPTION
There were two parameters in the `rx_download` project description (the .MD) that were misnamed.

1. First, the test bench had `SEGMENT_DISPLAY_US`, while the testbench had `MIN_SEGMENT_DISPLAY_US`.
2. Second, the same `DEBOUNCE_DELAY_US` that was changed last week was in the `tx_download` project description was still there.

Both have been updated _in the project description_.